### PR TITLE
refactor skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Visual representation of analytics on feedback.
+- Visual representation of analytics from Pivotal Tracker.
+
+## [2.0.1] - 2019-04-13
+### Changed
+- Only PT story labels starting with `skill:` will now be considered as skills.
+- A skill is now considered done when the containing story is either `accepted` or `delivered`.
 
 ## [2.0.0] - 2019-04-09
 ### Deprecated

--- a/src/analytics/PivotalTrackerAnalytics.js
+++ b/src/analytics/PivotalTrackerAnalytics.js
@@ -12,9 +12,10 @@ export default class PivotalTrackerAnalytics {
       let token = req.params.token;
       const query = jwt.verify(token, process.env.JWT_SECRET);
       const options = {
-        updated_after: query.startDate,
-        updated_before: query.endDate
+        updated_after: query.startDate + 'T00:00:00Z',
+        updated_before: query.endDate + 'T23:59:59Z'
       };
+      console.log(options)
       const items = await pivotal.project.fetchStories(query.projectId, options);
       let records = [];
       if (query.analyticsType === 'kanban_view') {

--- a/src/analytics/PivotalTrackerAnalytics.js
+++ b/src/analytics/PivotalTrackerAnalytics.js
@@ -12,8 +12,8 @@ export default class PivotalTrackerAnalytics {
       let token = req.params.token;
       const query = jwt.verify(token, process.env.JWT_SECRET);
       const options = {
-        updated_after: query.startDate + 'T00:00:00Z',
-        updated_before: query.endDate + 'T23:59:59Z'
+        updated_after: query.startDate,
+        updated_before: query.endDate
       };
       console.log(options)
       const items = await pivotal.project.fetchStories(query.projectId, options);

--- a/src/analytics/PivotalTrackerAnalytics.js
+++ b/src/analytics/PivotalTrackerAnalytics.js
@@ -152,9 +152,9 @@ async function _getSkillsVsUsers(items, projectId) {
   labels = labels.filter(l => l.name.toLowerCase().startsWith('skill:'));
   // get all hits
   filteredStories.forEach(s => {
-    s.labels.forEach(l => {
+    s.labels.forEach(l => {console.log('got here>>>>>>>>>>>>>>');console.log(l.name);
       if (l.name.toLowerCase().startsWith('skill:')) {
-        s.owner_ids.forEach(id => {console.log('got here>>>>>>>>>>>>>>');
+        s.owner_ids.forEach(id => {console.log('also got here>>>>>>>>>>>>>>');
           hits.push({
             userId: id,
             name: l.name,

--- a/src/analytics/PivotalTrackerAnalytics.js
+++ b/src/analytics/PivotalTrackerAnalytics.js
@@ -149,14 +149,12 @@ async function _getSkillsVsUsers(items, projectId) {
 
   // get all labels
   let labels = await pivotal.project.getLabels(projectId);
-  console.log(labels.length);
   labels = labels.filter(l => l.name.toLowerCase().startsWith('skill:'));
-  console.log(labels.length);
   // get all hits
   filteredStories.forEach(s => {
     s.labels.forEach(l => {
       if (l.name.toLowerCase().startsWith('skill:')) {
-        s.owner_ids.forEach(id => {
+        s.owner_ids.forEach(id => {console.log('got here>>>>>>>>>>>>>>');
           hits.push({
             userId: id,
             name: l.name,
@@ -165,7 +163,7 @@ async function _getSkillsVsUsers(items, projectId) {
         });
       }
     });
-  });
+  });console.log(hits);
   // create skills and their users
   for (let i = 0; i < labels.length; i++) {
     let label = labels[i];
@@ -187,11 +185,12 @@ async function _getSkillsVsUsers(items, projectId) {
           ongoingHits: h.state !== 'accepted' && h.state !== 'delivered' ? 1 : 0
         });
       }
-    });
+    });console.log(hitsMap)
     for (let [userId, hit] of hitsMap) {
       let user = await __getUserFromPt(userId);
       label.users.push({ ...user, ...hit });
     }
+    console.log(label);
     // use substring(...) to remove the first 6 characters 'skill:'
     records.push({ name: label.name.substring(6).trim(), users: label.users });
   }

--- a/src/core/HelperFunctions.js
+++ b/src/core/HelperFunctions.js
@@ -123,13 +123,13 @@ export default class HelperFunctions {
             label: 'Users and the skills they have touched',
             value: 'users_vs_skills'
           }, {
-            label: 'Skills and the users that touched them',
+            label: 'Skills and the users who touched them',
             value: 'skills_vs_users'
           },{
             label: 'Users and the stories they have touched',
             value: 'users_vs_stories'
           }, {
-            label: 'Stories and the users that touched them',
+            label: 'Stories and the users who touched them',
             value: 'stories_vs_users'
           }, {
             label: 'Kanban view',

--- a/src/core/InteractionHandler.js
+++ b/src/core/InteractionHandler.js
@@ -221,8 +221,8 @@ async function _handlePtAnalyticsDialog(req) {
   let query = {
     projectId,
     analyticsType: submission.analytics_type,
-    endDate: new Date(submission.analytics_end_date),
-    startDate: new Date(submission.analytics_start_date)
+    endDate: new Date(submission.analytics_end_date + 'T23:59:59Z'),
+    startDate: new Date(submission.analytics_start_date + 'T00:00:00Z')
   };
   if (submission.analytics_type === 'kanban_view') {
     returnUrl += '/kanban';


### PR DESCRIPTION
- Only PT story labels starting with `skill:` will now be considered as skills.
- A skill is now considered done when the containing story is either `accepted` or `delivered`.